### PR TITLE
Make the file upload work.

### DIFF
--- a/src/app/addimage/addimage.component.ts
+++ b/src/app/addimage/addimage.component.ts
@@ -32,11 +32,11 @@ export class AddimageComponent implements OnInit {
     if(fileList.length > 0) {
         let file: File = fileList[0];
         let formData:FormData = new FormData();
-        formData.append('uploadFile', file, file.name);
+        formData.append('file', file, file.name);
         this.dataservice.fileUpload(formData, this.tool.id)
     }
   }
 
   //apiEndPoint = POST "/api/tools/{toolId}/s3/upload"
-  
+
 }

--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -11,6 +11,7 @@ export class DataService {
 
     //all api calls start with this base. concat additional text for endpoint.
 
+    // private baseURL: string = "http://localhost:8080/api/";
     private baseURL: string = "https://communityshed.herokuapp.com/api/";
     status;
 
@@ -36,7 +37,7 @@ export class DataService {
             .catch(this.handleError)
     }
 
-    //login page 
+    //login page
 
     logIn(userData: object): Observable<any> {
         const objectToSend = JSON.stringify(userData);
@@ -161,7 +162,7 @@ export class DataService {
             .map(this.extractData)
             .catch(this.handleError)
     }
-    
+
     //enable tool
     enableTool(id): Observable<any> {
         let apiURL = `${this.baseURL}tools/${id}/enable`
@@ -174,7 +175,7 @@ export class DataService {
     createNewTool(toolData: object): Observable<any> {
         const objectToSend = JSON.stringify(toolData);
         const options: RequestOptionsArgs = {}
-    
+
         return this.http
             .post(this.baseURL + 'tools', objectToSend, this.commonHttpOptions)
             .map(this.extractData)
@@ -218,7 +219,6 @@ export class DataService {
     //upload file
     fileUpload(formData: FormData, id) {
         let headers = new Headers();
-        headers.append('Content-Type', 'multipart/form-data');
         headers.append('Accept', 'application/json');
         let options = new RequestOptions({ headers: headers });
         let apiURL = `${this.baseURL}tools/${id}/s3/upload`


### PR DESCRIPTION
The change in the data service removes the Content-Type header and
lets the XMLHttpRequest set the "multipart/form-data" value with
the appropriate value that contains the boundary information.

The change in addimage.component.ts changes the name of the
submitted field from 'uploadFile' to 'file' because the Java back-
end expects the field to be named 'file'.